### PR TITLE
Make configuration v0.12 compatible

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket" "remote_state" {
     enabled = true
   }
 
-  tags {
+  tags = {
     Name        = "${var.prefix}-remote-state-${var.environment}"
     Environment = "${var.environment}"
   }


### PR DESCRIPTION
These changes (intentionally) keep the configuration still 0.11 compatible.

I reckon when 0.12 final is out the configuration can be upgraded using the [upgrade guide](https://www.terraform.io/upgrade-guides/0-12.html) and `0.12upgrade` command.